### PR TITLE
Migrate all Vue components from Options API to Composition API

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,10 @@
 <!--
-This example fetches latest Vue.js commits data from GitHub’s API and displays them as a list.
+This example fetches latest Vue.js commits data from GitHub's API and displays them as a list.
 You can switch between the two branches.
 -->
 
-<script lang="ts">
+<script setup lang="ts">
+import { ref, computed } from 'vue';
 import AvailableAppointmentsList from './components/AvailableAppointmentsList.vue';
 import IconHelpTooltip from './components/icons/IconHelpTooltip.vue';
 import LocationsSelector from './components/LocationsSelector.vue';
@@ -18,107 +19,94 @@ const API_URL = `https://ttp.cbp.dhs.gov/schedulerapi/slots`;
 const DEFAULT_DELAY = 60000; // 1 minute
 const DEFAULT_DELAY_SECONDS = DEFAULT_DELAY / 1000;
 
-interface AppData {
-  appointments: Array<ApiAvailableSlots>;
-  shouldAutoRetry: boolean;
-  lastSearched: Date | null;
-  currentTimeoutIntervalId: number | null;
-  didFirstSearch: boolean;
-  activeSearch: boolean;
+const appointments = ref<ApiAvailableSlots[]>([]);
+const shouldAutoRetry = ref(true);
+const lastSearched = ref<Date | null>(null);
+const currentTimeoutIntervalId = ref<number | null>(null);
+const didFirstSearch = ref(false);
+const activeSearch = ref(false);
+
+const locationSelectorRef = ref<InstanceType<typeof LocationsSelector> | null>(null);
+const notificationCheckboxRef = ref<InstanceType<typeof NotificationCheckbox> | null>(null);
+
+const lastSearchDate = computed(() => lastSearched.value?.toLocaleString() || '--');
+const hasAvailableAppointments = computed(() => appointments.value.length > 0);
+const searchButtonClass = computed(() => (activeSearch.value ? 'secondary' : ''));
+const searchButtonText = computed(() => (activeSearch.value ? 'Searching...' : 'Search'));
+const defaultDelaySeconds = DEFAULT_DELAY_SECONDS;
+
+function clearFetchDataTimeout() {
+  if (currentTimeoutIntervalId.value) {
+    console.log('Clearing timeouts');
+    clearTimeout(currentTimeoutIntervalId.value);
+    currentTimeoutIntervalId.value = null;
+  }
 }
 
-export default {
-  components: {
-    AvailableAppointmentsList,
-    IconHelpTooltip,
-    LocationsSelector,
-    NotificationCheckbox,
-    PageFooter,
-    RetryCountdown,
-  },
+async function fetchData() {
+  activeSearch.value = true;
+  clearFetchDataTimeout();
+  const locationId = locationSelectorRef.value?.currentLocationId;
+  const url = `${API_URL}?orderBy=soonest&limit=1000&locationId=${locationId}&minimum=1`;
 
-  data: (): AppData => ({
-    appointments: [],
-    shouldAutoRetry: true,
-    lastSearched: null,
-    currentTimeoutIntervalId: null,
-    didFirstSearch: false,
-    activeSearch: false,
-  }),
+  const result = await abortableFetch<ApiAvailableSlots[]>(url);
 
-  computed: {
-    lastSearchDate() {
-      return this.lastSearched?.toLocaleString() || '--';
-    },
-    hasAvailableAppointments() {
-      return this.appointments.length > 0;
-    },
-    searchButtonClass() {
-      return this.activeSearch ? 'secondary' : '';
-    },
-    searchButtonText() {
-      return this.activeSearch ? 'Searching...' : 'Search';
-    },
-    defaultDelaySeconds() {
-      return DEFAULT_DELAY_SECONDS;
-    },
-  },
+  if (!result.ok) {
+    if (result.aborted) return;
+  } else {
+    lastSearched.value = new Date();
+    appointments.value = result.data;
+    didFirstSearch.value = true;
+  }
 
-  methods: {
-    clearFetchDataTimeout() {
-      if (this.currentTimeoutIntervalId) {
-        console.log('Clearing timeouts');
-        clearTimeout(this.currentTimeoutIntervalId);
-        this.currentTimeoutIntervalId = null;
-      }
-    },
-    async fetchData() {
-      this.activeSearch = true;
-      this.clearFetchDataTimeout();
-      const locationId = (this.$refs.locationSelectorRef as typeof LocationsSelector)
-        .currentLocationId;
-      const url = `${API_URL}?orderBy=soonest&limit=1000&locationId=${locationId}&minimum=1`;
+  activeSearch.value = false;
 
-      const result = await abortableFetch<ApiAvailableSlots[]>(url);
+  if (shouldAutoRetry.value) {
+    await delayFetchData(DEFAULT_DELAY);
+  }
 
-      if (!result.ok) {
-        if (result.aborted) return;
-      } else {
-        this.lastSearched = new Date();
-        this.appointments = result.data;
-        this.didFirstSearch = true;
-      }
+  if (hasAvailableAppointments.value) {
+    await sendNotification();
+  }
+}
 
-      this.activeSearch = false;
+async function sendNotification() {
+  if (notificationCheckboxRef.value?.notificationsEnabled) {
+    createNotification(appointments.value);
+  }
+}
 
-      if (this.shouldAutoRetry) {
-        await this.delayFetchData(DEFAULT_DELAY);
-      }
+async function changeAutoRetry() {
+  if (!shouldAutoRetry.value) {
+    clearFetchDataTimeout();
+  }
+}
 
-      if (this.hasAvailableAppointments) {
-        await this.sendNotification();
-      }
-    },
-    async sendNotification() {
-      if (
-        (this.$refs.notificationCheckboxRef as typeof NotificationCheckbox).notificationsEnabled
-      ) {
-        createNotification(this.appointments);
-      }
-    },
-    async changeAutoRetry() {
-      if (!this.shouldAutoRetry) {
-        this.clearFetchDataTimeout();
-      }
-    },
-    async delayFetchData(time: number) {
-      this.clearFetchDataTimeout();
-      this.currentTimeoutIntervalId = setTimeout(async () => {
-        await this.fetchData();
-      }, time);
-    },
-  },
-};
+async function delayFetchData(time: number) {
+  clearFetchDataTimeout();
+  currentTimeoutIntervalId.value = setTimeout(async () => {
+    await fetchData();
+  }, time);
+}
+
+defineExpose({
+  appointments,
+  shouldAutoRetry,
+  lastSearched,
+  currentTimeoutIntervalId,
+  didFirstSearch,
+  activeSearch,
+  lastSearchDate,
+  hasAvailableAppointments,
+  searchButtonClass,
+  searchButtonText,
+  defaultDelaySeconds,
+  clearFetchDataTimeout,
+  fetchData,
+  sendNotification,
+  changeAutoRetry,
+  delayFetchData,
+});
 </script>
 
 <template>

--- a/src/components/AvailableAppointment.vue
+++ b/src/components/AvailableAppointment.vue
@@ -1,4 +1,6 @@
-<script lang="ts">
+<script setup lang="ts">
+import { computed } from 'vue';
+
 const dateFormat = new Intl.DateTimeFormat(undefined, {
   weekday: 'long',
   year: 'numeric',
@@ -13,40 +15,24 @@ const timeFormat = new Intl.DateTimeFormat(undefined, {
 
 const MAX_VISIBLE_TIMES = 3;
 
-export default {
-  computed: {
-    date(): string {
-      return dateFormat.format((this.appointments as Date[])[0]);
-    },
-    firstTime(): string {
-      return timeFormat.format((this.appointments as Date[])[0]);
-    },
-    appointmentCount(): number {
-      return (this.appointments as Date[]).length;
-    },
-    appointmentLabel(): string {
-      return this.appointmentCount === 1 ? 'appointment' : 'appointments';
-    },
-    visibleTimes(): string[] {
-      return (this.appointments as Date[])
-        .slice(0, MAX_VISIBLE_TIMES)
-        .map((d) => timeFormat.format(d));
-    },
-    hiddenTimes(): string[] {
-      return (this.appointments as Date[])
-        .slice(MAX_VISIBLE_TIMES)
-        .map((d) => timeFormat.format(d));
-    },
-    hasMoreTimes(): boolean {
-      return (this.appointments as Date[]).length > MAX_VISIBLE_TIMES;
-    },
-    moreCount(): number {
-      return (this.appointments as Date[]).length - MAX_VISIBLE_TIMES;
-    },
-  },
+const props = defineProps<{
+  appointments: Date[];
+}>();
 
-  props: ['appointments'],
-};
+const date = computed(() => dateFormat.format(props.appointments[0]));
+const firstTime = computed(() => timeFormat.format(props.appointments[0]));
+const appointmentCount = computed(() => props.appointments.length);
+const appointmentLabel = computed(() =>
+  appointmentCount.value === 1 ? 'appointment' : 'appointments',
+);
+const visibleTimes = computed(() =>
+  props.appointments.slice(0, MAX_VISIBLE_TIMES).map((d) => timeFormat.format(d)),
+);
+const hiddenTimes = computed(() =>
+  props.appointments.slice(MAX_VISIBLE_TIMES).map((d) => timeFormat.format(d)),
+);
+const hasMoreTimes = computed(() => props.appointments.length > MAX_VISIBLE_TIMES);
+const moreCount = computed(() => props.appointments.length - MAX_VISIBLE_TIMES);
 </script>
 
 <template>

--- a/src/components/AvailableAppointmentsList.vue
+++ b/src/components/AvailableAppointmentsList.vue
@@ -1,4 +1,5 @@
-<script lang="ts">
+<script setup lang="ts">
+import { computed } from 'vue';
 import AvailableAppointment from './AvailableAppointment.vue';
 import type { ApiAvailableSlots } from '../apiTypes';
 
@@ -7,34 +8,28 @@ interface DateGroup {
   appointments: Date[];
 }
 
-export default {
-  components: {
-    AvailableAppointment,
-  },
+const props = defineProps<{
+  appointments: ApiAvailableSlots[];
+}>();
 
-  computed: {
-    groupedAppointments(): DateGroup[] {
-      const groups: DateGroup[] = [];
-      let currentGroup: DateGroup | null = null;
+const groupedAppointments = computed<DateGroup[]>(() => {
+  const groups: DateGroup[] = [];
+  let currentGroup: DateGroup | null = null;
 
-      for (const slot of this.appointments as ApiAvailableSlots[]) {
-        const appointmentDate = new Date(slot.startTimestamp);
-        const dateKey = appointmentDate.toDateString();
+  for (const slot of props.appointments) {
+    const appointmentDate = new Date(slot.startTimestamp);
+    const dateKey = appointmentDate.toDateString();
 
-        if (!currentGroup || currentGroup.dateKey !== dateKey) {
-          currentGroup = { dateKey, appointments: [appointmentDate] };
-          groups.push(currentGroup);
-        } else {
-          currentGroup.appointments.push(appointmentDate);
-        }
-      }
+    if (!currentGroup || currentGroup.dateKey !== dateKey) {
+      currentGroup = { dateKey, appointments: [appointmentDate] };
+      groups.push(currentGroup);
+    } else {
+      currentGroup.appointments.push(appointmentDate);
+    }
+  }
 
-      return groups;
-    },
-  },
-
-  props: ['appointments'],
-};
+  return groups;
+});
 </script>
 
 <template>

--- a/src/components/LocationsSelector.vue
+++ b/src/components/LocationsSelector.vue
@@ -1,16 +1,16 @@
-<script lang="ts">
+<script setup lang="ts">
+import { ref } from 'vue';
 import LocationsData from '../assets/locations.json';
 
 const DEFAULT_LOCATION_ID = 5446; // San Francisco Enrollment Center
 
-export default {
-  data() {
-    return {
-      locations: LocationsData.sort((a, b) => (a.name > b.name ? 1 : -1)),
-      currentLocationId: DEFAULT_LOCATION_ID,
-    };
-  },
-};
+const locations = LocationsData.sort((a, b) => (a.name > b.name ? 1 : -1));
+const currentLocationId = ref(DEFAULT_LOCATION_ID);
+
+defineExpose({
+  locations,
+  currentLocationId,
+});
 </script>
 
 <template>

--- a/src/components/NotificationCheckbox.vue
+++ b/src/components/NotificationCheckbox.vue
@@ -1,25 +1,17 @@
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { ref } from 'vue';
 import IconHelpTooltip from './icons/IconHelpTooltip.vue';
 
-export default defineComponent({
-  components: {
-    IconHelpTooltip,
-  },
+const notificationsEnabled = ref(false);
 
-  data() {
-    return {
-      notificationsEnabled: false,
-    };
-  },
+async function changeNotifications() {
+  if (notificationsEnabled.value && Notification.permission !== 'denied') {
+    await Notification.requestPermission();
+  }
+}
 
-  methods: {
-    async changeNotifications() {
-      if (this.notificationsEnabled && Notification.permission !== 'denied') {
-        await Notification.requestPermission();
-      }
-    },
-  },
+defineExpose({
+  notificationsEnabled,
 });
 </script>
 

--- a/src/components/PageFooter.vue
+++ b/src/components/PageFooter.vue
@@ -1,19 +1,8 @@
-<script lang="ts">
+<script setup lang="ts">
 import SvgIcon from '@jamescoyle/vue-icon';
 import { mdiGithub } from '@mdi/js';
 
-interface PageFooterComponentData {
-  githubIconSvgPath: string;
-}
-
-export default {
-  components: {
-    SvgIcon,
-  },
-  data: (): PageFooterComponentData => ({
-    githubIconSvgPath: mdiGithub,
-  }),
-};
+const githubIconSvgPath = mdiGithub;
 </script>
 
 <template>

--- a/src/components/RetryCountdown.vue
+++ b/src/components/RetryCountdown.vue
@@ -1,65 +1,54 @@
-<script lang="ts">
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+
 const DEFAULT_INTERVAL = 1000;
 
-interface RetryCountdownData {
-  secondsLeft: number;
-  countdownIntervalId: number | null;
+const props = defineProps<{
+  totalSeconds: number;
+}>();
+
+const secondsLeft = ref(props.totalSeconds);
+const countdownIntervalId = ref<number | null>(null);
+
+const unitLabel = computed(() => (secondsLeft.value === 1 ? 'second' : 'seconds'));
+
+function startCountdown() {
+  countdownIntervalId.value = setInterval(() => {
+    secondsLeft.value--;
+    if (secondsLeft.value <= 0) {
+      stopCountdown();
+    }
+  }, DEFAULT_INTERVAL);
 }
 
-export default {
-  props: {
-    totalSeconds: {
-      type: Number,
-      required: true,
-    },
-  },
+function stopCountdown() {
+  if (countdownIntervalId.value) {
+    clearInterval(countdownIntervalId.value);
+    countdownIntervalId.value = null;
+  }
+}
 
-  data(): RetryCountdownData {
-    return {
-      secondsLeft: this.totalSeconds,
-      countdownIntervalId: null,
-    };
-  },
+onMounted(() => {
+  startCountdown();
+});
 
-  computed: {
-    unitLabel(): string {
-      return this.secondsLeft === 1 ? 'second' : 'seconds';
-    },
-  },
+onBeforeUnmount(() => {
+  stopCountdown();
+});
 
-  mounted() {
-    this.startCountdown();
+watch(
+  () => props.totalSeconds,
+  (newVal) => {
+    stopCountdown();
+    secondsLeft.value = newVal;
+    startCountdown();
   },
+);
 
-  beforeUnmount() {
-    this.stopCountdown();
-  },
-
-  watch: {
-    totalSeconds(newVal: number) {
-      this.stopCountdown();
-      this.secondsLeft = newVal;
-      this.startCountdown();
-    },
-  },
-
-  methods: {
-    startCountdown() {
-      this.countdownIntervalId = setInterval(() => {
-        this.secondsLeft--;
-        if (this.secondsLeft <= 0) {
-          this.stopCountdown();
-        }
-      }, DEFAULT_INTERVAL);
-    },
-    stopCountdown() {
-      if (this.countdownIntervalId) {
-        clearInterval(this.countdownIntervalId);
-        this.countdownIntervalId = null;
-      }
-    },
-  },
-};
+defineExpose({
+  secondsLeft,
+  countdownIntervalId,
+});
 </script>
 
 <template>

--- a/src/components/icons/IconHelpTooltip.vue
+++ b/src/components/icons/IconHelpTooltip.vue
@@ -1,18 +1,12 @@
-<script lang="ts">
+<script setup lang="ts">
 import SvgIcon from '@jamescoyle/vue-icon';
 import { mdiHelpCircleOutline } from '@mdi/js';
 
-export default {
-  components: {
-    SvgIcon,
-  },
-  data() {
-    return {
-      path: mdiHelpCircleOutline,
-    };
-  },
-  props: ['tooltip'],
-};
+defineProps<{
+  tooltip: string;
+}>();
+
+const path = mdiHelpCircleOutline;
 </script>
 
 <template>


### PR DESCRIPTION
Replace Options API patterns (data, computed, methods, watch, lifecycle
hooks) with Composition API equivalents using <script setup>. Uses ref()
for reactive state, computed() for derived values, and standard functions
for methods. Components that expose state to parent refs or tests use
defineExpose(). Props use type-based defineProps<>() declarations.

https://claude.ai/code/session_01ARYWRRfVAx42wNP6EiPuLc