### PR TITLE
Configure dependabot to only update direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       interval: 'weekly'
     assignees:
       - 'gcorreaq'
+    allow:
+      - dependency-type: 'direct'
     groups:
       # Group ESLint/Prettier packages together to avoid peer dependency conflicts
       linting:


### PR DESCRIPTION
Adds `allow: dependency-type: direct` so version-update PRs are only
opened for packages listed directly in package.json. Transitive
dependency security updates are unaffected — Dependabot ignores this
filter for security alerts.

https://claude.ai/code/session_01RvN5gsEjPyFVDbgSsrXZST