### PR TITLE
ci: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci-on-pull-request.yaml
+++ b/.github/workflows/ci-on-pull-request.yaml
@@ -14,8 +14,8 @@ jobs:
     name: 'eslint'
     runs-on: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -25,8 +25,8 @@ jobs:
   type-check:
     runs-on: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -36,8 +36,8 @@ jobs:
   formatting:
     runs-on: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -47,8 +47,8 @@ jobs:
   test:
     runs-on: [ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         with:
           command: manifest

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,5 +14,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
-        with:
-          command: manifest


### PR DESCRIPTION
- actions/checkout: v4 → v6
- actions/setup-node: v4 → v6
- google-github-actions/release-please-action@v3 → googleapis/release-please-action@v4 (repo moved)

https://claude.ai/code/session_01UYP4sF9wuMUVX5KP8RdxVe