### PR TITLE
improve dependabot config with missing ecosystems and groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,10 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    directory: '/' # Location of package manifests
+    directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
     assignees:
       - 'gcorreaq'
     allow:
@@ -27,9 +28,35 @@ updates:
           - 'typescript'
           - 'vue-tsc'
           - '@vue/tsconfig'
+          - '@tsconfig/*'
+          - '@types/*'
       # Group testing packages together
       testing:
         patterns:
           - 'vitest'
           - '@vue/test-utils'
           - 'jsdom'
+      # Group Vite and its plugins together
+      vite:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+      # Group general build/workflow utilities together
+      tooling:
+        patterns:
+          - 'husky'
+          - 'lint-staged'
+          - 'npm-run-all'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    assignees:
+      - 'gcorreaq'
+    groups:
+      # Group all GitHub Actions together for a single review PR
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
- Add github-actions ecosystem to track actions/checkout,
  actions/setup-node, and googleapis/release-please-action updates
- Add vite group for vite + @vitejs/* packages
- Add tooling group for husky, lint-staged, npm-run-all
- Extend typescript group to include @tsconfig/* and @types/*
- Pin weekly schedule to Monday for predictable update cadence
- Remove redundant inline comment from npm directory field

https://claude.ai/code/session_01A1EKuD6HW7GogtL7nfLxTz