### PR TITLE
chore: limit GitHub Actions Dependabot updates to major versions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,11 @@ updates:
       day: 'monday'
     assignees:
       - 'gcorreaq'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
     groups:
       # Group all GitHub Actions together for a single review PR
       github-actions:


### PR DESCRIPTION
Add ignore rules for semver-minor and semver-patch update types on the
github-actions ecosystem so only breaking/major version bumps generate PRs.

https://claude.ai/code/session_01VEkPjzbHPQbrFpYuAxBtqR